### PR TITLE
Display attribute of span is now inline instead of inline-flex, and removed redundant whitespaces around spoiler part.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { createHash } from "crypto";
 // language=css
 const baseCSS = `
 .spoiler {
-  display: inline-flex;
+  display: inline;
 }
 p.spoiler {
   display: flex;
@@ -104,10 +104,7 @@ hexo.extend.tag.register("spoiler", function(args) {
   const colorDef = color ? `<!-- spoiler-${hashedName(color)}:${color} -->` : "";
   const tag = p ? "p" : "span";
 
-  return `${colorDef}
-  <${tag} class="spoiler" onclick="this.classList.toggle('spoiler')">
-    <span class="spoiler-${style} ${colorClass}">${content}</span>
-  </${tag}>`;
+  return `${colorDef}<${tag} class="spoiler" onclick="this.classList.toggle('spoiler')"><span class="spoiler-${style} ${colorClass}">${content}</span></${tag}>`;
 });
 
 hexo.extend.filter.register("after_render:html", document => {


### PR DESCRIPTION
# Changes
1. Display attribute of `<span/>` wrapping spoiler text: `inline-flex` is replaced by `inline`. This makes the spoiler text wrapped by `<span/>` support line breaks, so multiline spoiler text wrapped by `<span/>` can be displayed inline rather than as a block.
2. Redundant whitespaces around the spoiler text are removed, but the HTML code for the spoiler text and the tag that wraps it becomes not properly indented.

# Screenshots
- Before:
![Screenshot_2024-02-18-13-28-51_1920x1080](https://github.com/unnamed42/hexo-spoiler/assets/60517035/f9aef727-53da-44e5-81d8-dedd77660741)
![Screenshot_2024-02-18-13-33-39_1920x1080](https://github.com/unnamed42/hexo-spoiler/assets/60517035/1856bf35-1864-47c5-b6c5-027d935c281d)

- After:
![Screenshot_2024-02-18-13-32-30_1920x1080](https://github.com/unnamed42/hexo-spoiler/assets/60517035/b2f590e6-347f-414e-a324-998287cf84ba)
![Screenshot_2024-02-18-13-32-48_1920x1080](https://github.com/unnamed42/hexo-spoiler/assets/60517035/b79b4847-29b8-4062-aada-4de11fc4ff92)
